### PR TITLE
Refactor: split playbook into roles; separate macOS defaults roles

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,6 +28,51 @@ This guide is adapted from [@geerlingguy](https://github.com/geerlingguy) 's [Ma
 
 > Note: If some Homebrew commands fail, you might need to agree to Xcode's license or fix some other Brew issue. Run brew doctor to see if this is the case.
 
+## Structure (roles-first)
+
+This playbook is now split into composable roles. The entry point `main.yml` lists roles in execution order.
+
+Roles in this repo:
+
+- `preflight`: quick sudo/password check and hello.
+- `dotfiles`: clone/update `TheClooneyCollection/dotfiles` into `~/`.
+- `ssh`: optionally generate SSH keypair (gated by `generate_ssh`).
+- `homebrew_base`: installs/configures Homebrew via `geerlingguy.mac.homebrew` and registers `brew_prefix`.
+- `dev_tools`: command-line formulae (git, fzf, ripgrep, languages, swift tools, etc.).
+- `casks`: GUI apps and utilities.
+- `shared_fonts`: shared font installation helper (kept as-is, separate role in `roles/shared_fonts`).
+- `emacs`: Emacs Plus + Spacemacs setup.
+- `vim`: Vim + YouCompleteMe bootstrap/compile.
+- `python_env`: pip `ansible`, install `poetry`, run `poetry install`.
+- `shell_fish`: default shell to fish.
+- `fzf`: run fzf installer.
+- `folders`: create `~/Source/{Projects,Forks,Work}`.
+- `macos_finder`: Finder defaults.
+- `macos_stage_manager`: Stage Manager defaults.
+- `macos_dock`: Dock & Mission Control defaults.
+
+Global variables remain defined at the play level in `main.yml` (e.g., `homebrew_user`, `homebrew_group`, `generate_ssh`, `ssh_*`).
+
+## Tags and targeted runs
+
+Common tags: `homebrew`, `homebrew-setup`, `dotfiles`, `ssh`, `spacemacs`, `vim`, `python`, `poetry`, `fishshell`, `fzf`, `folder-structure`, `finder`, `stage-manager`, `dock`.
+
+Examples:
+
+- List tags: `ansible-playbook -i inventory --list-tags main.yml`
+- Syntax check: `ansible-playbook -i inventory --syntax-check main.yml`
+- Dry run: `ansible-playbook -i inventory -K --check --diff main.yml`
+- Homebrew base + dev tools + casks: `ansible-playbook -i inventory -K main.yml --tags homebrew`
+- Fonts only: `ansible-playbook -i inventory -K main.yml --tags homebrew` (ensures brew) then `--tags fonts` if you add a `fonts` tag to your run, or run entire play (this repo's fonts are invoked via role `shared_fonts`).
+- macOS UI defaults: `ansible-playbook -i inventory -K main.yml --tags finder,stage-manager,dock`
+- Editors: `ansible-playbook -i inventory -K main.yml --tags spacemacs,vim`
+- SSH generation: `ansible-playbook -i inventory -K main.yml --tags ssh -e generate_ssh=true`
+
+Notes on dependencies when targeting:
+
+- Some roles rely on `homebrew_base` to have run (because it registers `brew_prefix` and ensures Homebrew): `emacs`, `python_env`, and `fzf` in particular. When running these tags alone, include `homebrew` too, e.g.: `--tags homebrew,spacemacs` or `--tags homebrew,python`.
+- `casks` and `dev_tools` also assume Homebrew is installed; include `--tags homebrew` if you are targeting them on a fresh machine.
+
 ## Credits
 
 This project is inspired by other people's work, namely:

--- a/main.yml
+++ b/main.yml
@@ -15,517 +15,55 @@
     ssh_private_key_path: "~/.ssh/id_{{ ssh_type }}"
     ssh_keygen_command: "ssh-keygen -o -t {{ ssh_type }} -a {{ ssh_rounds }} -N '{{ passphrase.user_input }}' -f {{ ssh_private_key_path }}"
 
-  tasks:
-    - name: Let me check your password first
-      command: echo "Password test in progress..."
-      timeout: 1
-      become: true
-      changed_when: false
+  roles:
+    - role: preflight
 
-    - debug:
-        msg: Hello, World!
+    - role: dotfiles
+      tags: [dotfiles]
 
-    - name: Set up my dotfile
-      tags: dotfiles
-      block:
-
-      - name: Clone the dotfile repo into the home directory `~`
-        shell:
-          cmd: |
-            cd ~
-            git init
-            git remote add origin https://github.com/TheClooneyCollection/dotfiles.git
-            git fetch origin
-            git switch -c main --track origin/main
-          creates: ~/.git
-        register: cloned_dotfile
-
-      # Using the `git` module will reset local branch to the main in remote
-      # which sometimes will drop local commits that haven't been pushed into remote yet...
-      # which is why we are just doing `git pull --rebase` here...
-      - name: Update the dotfile repo
-        command:
-          cmd: git pull --rebase
-          chdir: ~/
-        when: not cloned_dotfile.changed
-        register: updated_dotfile
-        changed_when: '"Already up to date" not in updated_dotfile.stdout'
-        # Note: `cloned_dotfile is skipped` does not work here.
-        # I assume that's because the `shell` module always runs.
-
-    - name: Set up SSH key pair
-      tags: ssh
+    - role: ssh
       when: generate_ssh
-      block:
+      tags: [ssh]
 
-      - name: Check if SSH key pair exists
-        stat:
-          path: "{{ ssh_private_key_path }}"
-        register: ssh_private_key
+    - role: homebrew_base
+      tags: [homebrew, homebrew-setup]
 
-      - name: Set up SSH key pair
-        block:
+    - role: dev_tools
+      tags: [homebrew]
 
-          - name: Get the passphrase for the SSH key pair
-            pause:
-              prompt: "Enter the passphrase"
-              echo: no
-            register: passphrase
+    - role: casks
+      tags: [homebrew]
 
-          - name: Generate the SSH key pair
-            command: "{{ ssh_keygen_command }}"
-
-        when: not ssh_private_key.stat.exists
-        no_log: true
-
-    - name: Set up Homebrew (and upgrade all packages)
-      include_role:
-        name: geerlingguy.mac.homebrew
+    - role: shared_fonts
       vars:
-        # homebrew_upgrade_all_packages: false # add a var to override
-        # homebrew_installed_packages:
-        # homebrew_uninstalled_packages:
-        # homebrew_cask_apps:
-        # homebrew_cask_uninstalled_apps:
-      tags:
-        - homebrew
-        - homebrew-setup
+        fonts:
+          - font-inconsolata-g-for-powerline
+          - font-source-code-pro
+          - font-source-code-pro-for-powerline
 
-    - name: Get Homebrew's prefix
-      command: brew --prefix
-      register: brew_prefix
-      changed_when: false
-      tags:
-        - homebrew
+    - role: emacs
+      tags: [spacemacs]
 
-    - name: Spacemacs Block
-      tags: spacemacs
-      block:
-      - name: Tap the Emacs Plus repository
-        homebrew_tap:
-          name: d12frosted/emacs-plus
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
+    - role: vim
+      tags: [vim]
 
-      - name: Install Emacs Plus
-        homebrew:
-          name: emacs-plus@30
-          install_options: with-elrumo2-icon
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
+    - role: python_env
+      tags: [python]
 
-      - name: Start Emacs Plus Service
-        command: brew services start d12frosted/emacs-plus/emacs-plus@30
-        register: start_emacs_service
-        changed_when: '"Successfully started" in start_emacs_service.stdout'
+    - role: shell_fish
+      tags: [fishshell]
 
-      - name: Symlink the Emacs.app to /Applications
-        file:
-          src: "{{ brew_prefix.stdout }}/opt/emacs-plus@30/Emacs.app"
-          dest: /Applications/Emacs.app
-          state: link
+    - role: fzf
+      tags: [fzf]
 
-      - name: Check if Spacemacs has been initialized
-        stat:
-          path: ~/.emacs.d/
-        register: spacemacs_stat
+    - role: folders
+      tags: [folder-structure]
 
-      - name: Keep Spacemacs up-to-date
-        git:
-          repo: https://github.com/syl20bnr/spacemacs.git
-          dest: ~/.emacs.d/
-          version: develop
+    - role: macos_finder
+      tags: [finder]
 
-    - name: Vim Block # Caveats: Vim's plugins aren't installed after this...
-      tags: vim
-      block:
-      - name: Install Vim
-        homebrew:
-          name: "{{ item }}"
-        loop:
-          - vim
-          - cmake # needed by YouCompleteMe
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
+    - role: macos_stage_manager
+      tags: [stage-manager]
 
-      - name: Check if Vim plugins are installed
-        stat:
-          path: ~/.vim-plugins/
-        register: vim_plugins_stat
-
-      - name: Bootstrap Vim plugins if plugins are not installed yet
-        command: vim
-        async: 90 # Give Vim one minute and half to run
-        poll: 0 # in the background
-        when: not vim_plugins_stat.stat.exists
-
-      # Caveat: Due to the nature of how Vim and its plugins are installed,
-      # YouCompleteMe won't be installed on the first run of the playbook...
-
-      - name: Check if YouCompleteMe is there
-        stat:
-          path: ~/.vim-plugins/plugins/YouCompleteMe/
-        register: YCM_stat
-
-      - name: Check if YouCompleteMe has been compiled
-        stat:
-          path: ~/.vim-plugins/plugins/YouCompleteMe/.compiled
-        register: YCM_compiled
-
-      - name: Compile YouCompleteMe
-        block:
-
-        - name: Compile YouCompleteMe
-          command:
-            cmd: python3 install.py
-            chdir: ~/.vim-plugins/plugins/YouCompleteMe
-
-        - name: Mark YCM as compiled
-          file:
-            path: ~/.vim-plugins/plugins/YouCompleteMe/.compiled
-            state: touch
-
-        when: YCM_stat.stat.exists and not YCM_compiled.stat.exists
-
-    - name: Install Homebrew packages and casks
-      block:
-
-      - name: Install Homebrew packages
-        homebrew:
-          name: "{{ item }}"
-          state: present
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
-        loop:
-          # commandline utilities
-
-          - fish
-          - tree
-          - zoxide # cd is lame, comparatively. zoxide is awesome.
-          - thefuck
-
-          # git
-
-          - git
-          - gh # github
-          - git-lfs
-          - git-delta # diff for git and magit
-
-          # editors support
-
-          - fzf # needed by fish and also vim for searching
-
-          - ripgrep # needed by emacs for searching
-          - ispell # needed by emacs for spell checks
-
-          # languages
-
-          - python
-          - ipython
-          - rbenv
-          - node
-          - yarn
-
-          # Swift
-
-          # - carthage # Until SPM solves its binary caches on CI, carthage is our friend...
-          - swiftgen
-          - swiftformat
-
-      - name: Check whether Xcode exists
-        command:
-          cmd: xcodebuild -version
-        ignore_errors: true
-        register: xcodebuild
-
-      - name: Install Homebrew packages requiring Xcode
-        homebrew:
-          name: "{{ item }}"
-          state: present
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
-        loop:
-          - swiftlint
-        when: xcodebuild is succeeded
-
-      - name: Install Homebrew Casks
-        homebrew_cask:
-          name: "{{ item }}"
-          state: present
-        become: "{{ (homebrew_user != ansible_user_id) | bool }}"
-        become_user: "{{ homebrew_user }}"
-        loop:
-
-          # macOS must-haves
-
-          - 1password
-          - 1password-cli
-          - dropbox
-          - firefox
-          - sublime-text
-          - obsidian
-          # - little-snitch
-
-          # work / life?
-
-          # - zoom
-          # - slack # needed for the huddles
-          # - docker
-          # - jq
-
-          - protonvpn
-          - parsec
-
-          # macOS quality of life improvements
-
-          - alfred
-          # - bartender
-          - caffeine
-          - istat-menus
-          - iterm2
-          # - moom
-          # - lunar
-
-          # 3d modeling & printing
-
-          - autodesk-fusion
-          - bambu-studio
-
-          # gaming
-
-          - steam
-
-          # streaming / recording
-
-          - obs
-          # - audio-hijack
-          - loopback
-
-          - vlc
-          - elgato-stream-deck
-
-          # lightroom
-
-          # - adobe-creative-cloud
-
-          # MIA
-
-          # mas 'DaisyDisk', id: 411643860
-          # mas 'GIPHY CAPTURE', id: 668208984
-          # mas 'Disk Care', id: 913724705
-
-      - name: Install shared fonts
-        include_role:
-          name: shared_fonts
-        vars:
-          fonts:
-            - font-inconsolata-g-for-powerline
-            - font-source-code-pro
-            - font-source-code-pro-for-powerline
-
-    - name: Set up Python development environment
-      tags: python
-      block:
-
-      - name: Ensure Ansible is installed with Homebrew's pip
-        pip:
-          name: ansible
-        vars:
-          extra_path: "{{ brew_prefix.stdout }}/bin"
-        tags:
-          - ansible
-
-      # It's much easier to install poetry with Homebrew
-      # Than using the installer...
-      # For some reason it really like the `~/Library/Python/3.9/bin` path...
-      - name: Install poetry
-        homebrew:
-          name: poetry
-        become: true
-        become_user: "{{ homebrew_user }}"
-        tags: poetry
-
-      - name: Set Up The Root Virtual Environment
-        command:
-          cmd: poetry install --no-root
-          chdir: ~/
-          creates: ~/poetry.lock
-        tags: poetry
-
-    # Set up fishshell as the default shell #
-
-    - name: Set up fishshell as the default shell
-      tags: fishshell
-      block:
-
-      - name: Get fishshell's path
-        command: which fish
-        register: fish
-        changed_when: false
-
-      - name: Ensure fishshell is included in /etc/shells
-        lineinfile:
-          path: /etc/shells
-          line: "{{ fish.stdout }}"
-        become: true
-
-      - name: Ensure current user's default shell is fish
-        user:
-          name: "{{ ansible_user_id }}"
-          shell: "{{ fish.stdout }}"
-        become: true
-
-    - name: Configure fzf
-      command:
-        cmd: "{{ brew_prefix.stdout }}/opt/fzf/install"
-        creates: ~/.fzf.bash
-      tags: fzf
-
-    - name: Set up my folder structure
-      file:
-        path: "{{ item }}"
-        state: directory
-      loop:
-        - ~/Source/Projects
-        - ~/Source/Forks
-        - ~/Source/Work
-      tags: folder-structure
-
-    - name: Configure Finder
-      tags: finder
-      block:
-
-      - name: Show path bar
-        osx_defaults:
-          domain: com.apple.finder
-          key: ShowPathbar
-          type: bool
-          value: true
-          state: present
-        register: finder_path_bar
-
-      - name: Show column view by default
-        osx_defaults:
-          domain: com.apple.finder
-          key: FXPreferredViewStyle
-          type: string
-          value: clmv
-          state: present
-        register: finder_column_view
-
-      - name: Keep folders on top
-        osx_defaults:
-          domain: com.apple.finder
-          key: _FXSortFoldersFirst
-          type: bool
-          value: true
-          state: present
-        register: finder_folders_on_top
-
-      - name: Search current folder by default
-        osx_defaults:
-          domain: com.apple.finder
-          key: FXDefaultSearchScope
-          type: string
-          value: SCcf
-          state: present
-        register: finder_search_current_folder
-
-      - name: Remove outdated (30 days) trash items
-        osx_defaults:
-          domain: com.apple.finder
-          key: FXRemoveOldTrashItems
-          type: bool
-          value: true
-          state: present
-        register: finder_trash_old_trash
-
-    - name: Configure Stage Manager
-      tags: stage-manager
-      block:
-
-      # Found a few settings here: https://forum.latenightsw.com/t/stage-manager-control-from-applescript/4303
-      # `GloballyEnabled`: Enabled or not
-      # `AppWindowGroupingBehavior`: Show windows from an application - All at once vs. One at a time
-      # `HideDesktop`: Show items in Stage Manager
-
-      - name: Enable Stage Manager
-        osx_defaults:
-          domain: com.apple.WindowManager
-          key: GloballyEnabled
-          type: bool
-          value: true
-          state: present
-
-      - name: Show desktop items in Stage Manager
-        osx_defaults:
-          domain: com.apple.WindowManager
-          key: HideDesktop
-          type: bool
-          value: false
-          state: present
-
-    - name: Configure Dock & Mission Control
-      tags: dock
-      block:
-
-      - name: On your right
-        osx_defaults:
-          domain: com.apple.dock
-          key: orientation
-          type: string
-          value: right
-          state: present
-        register: dock_is_right
-
-      - name: Duck!
-        osx_defaults:
-          domain: com.apple.dock
-          key: autohide
-          type: bool
-          value: true
-          state: present
-        register: dock_duck
-
-      - name: Don't you dare to bounce (Dock icons, I am talking to you)
-        osx_defaults:
-          domain: com.apple.dock
-          key: no-bouncing
-          type: bool
-          value: true
-          state: present
-        register: dock_no_bounce
-
-      - name: Only show me running apps in the Dock
-        block:
-
-        - name: Only show me running apps in the Dock
-          osx_defaults:
-            domain: com.apple.dock
-            key: static-only
-            type: bool
-            value: true
-            state: present
-          register: dock_only_running_apps
-
-        - name: No suggested and recent apps in the Dock please
-          osx_defaults:
-            domain: com.apple.dock
-            key: show-recents
-            type: bool
-            value: false
-            state: present
-          register: dock_no_suggestion_no_recents
-
-      - name: Don't rearrange my spaces please
-        osx_defaults:
-          domain: com.apple.dock
-          key: mru-spaces
-          type: bool
-          value: false
-          state: present
-        register: mission_control_no_auto_rearrange
-
-      - name: Kill it! Kill it now! (Dock)
-        command: killall Dock
-        when: dock_is_right.changed or dock_duck.changed or dock_no_bounce.changed or dock_only_running_apps.changed or dock_no_suggestion_no_recents.changed or mission_control_no_auto_rearrange.changed
+    - role: macos_dock
+      tags: [dock]

--- a/roles/casks/tasks/main.yml
+++ b/roles/casks/tasks/main.yml
@@ -1,0 +1,60 @@
+---
+- name: Install Homebrew Casks
+  homebrew_cask:
+    name: "{{ item }}"
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  loop:
+    # macOS must-haves
+    - 1password
+    - 1password-cli
+    - dropbox
+    - firefox
+    - sublime-text
+    - obsidian
+    # - little-snitch
+
+    # work / life?
+    # - zoom
+    # - slack
+    # - docker
+    # - jq
+
+    - protonvpn
+    - parsec
+
+    # macOS quality of life improvements
+    - alfred
+    # - bartender
+    - caffeine
+    - istat-menus
+    - iterm2
+    # - moom
+    # - lunar
+
+    # 3d modeling & printing
+    - autodesk-fusion
+    - bambu-studio
+
+    # gaming
+    - steam
+
+    # streaming / recording
+    - obs
+    # - audio-hijack
+    - loopback
+
+    - vlc
+    - elgato-stream-deck
+
+    # lightroom
+    # - adobe-creative-cloud
+
+    # MIA
+    # mas 'DaisyDisk', id: 411643860
+    # mas 'GIPHY CAPTURE', id: 668208984
+    # mas 'Disk Care', id: 913724705
+  tags:
+    - homebrew
+

--- a/roles/dev_tools/tasks/main.yml
+++ b/roles/dev_tools/tasks/main.yml
@@ -1,0 +1,59 @@
+---
+- name: Install Homebrew packages
+  homebrew:
+    name: "{{ item }}"
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  loop:
+    # commandline utilities
+    - fish
+    - tree
+    - zoxide
+    - thefuck
+
+    # git
+    - git
+    - gh
+    - git-lfs
+    - git-delta
+
+    # editors support
+    - fzf
+    - ripgrep
+    - ispell
+
+    # languages
+    - python
+    - ipython
+    - rbenv
+    - node
+    - yarn
+
+    # Swift
+    # - carthage
+    - swiftgen
+    - swiftformat
+  tags:
+    - homebrew
+
+- name: Check whether Xcode exists
+  command:
+    cmd: xcodebuild -version
+  ignore_errors: true
+  register: xcodebuild
+  tags:
+    - homebrew
+
+- name: Install Homebrew packages requiring Xcode
+  homebrew:
+    name: "{{ item }}"
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  loop:
+    - swiftlint
+  when: xcodebuild is succeeded
+  tags:
+    - homebrew
+

--- a/roles/dotfiles/tasks/main.yml
+++ b/roles/dotfiles/tasks/main.yml
@@ -1,0 +1,24 @@
+---
+- name: Set up my dotfile
+  tags: dotfiles
+  block:
+
+  - name: Clone the dotfile repo into the home directory `~`
+    shell:
+      cmd: |
+        cd ~
+        git init
+        git remote add origin https://github.com/TheClooneyCollection/dotfiles.git
+        git fetch origin
+        git switch -c main --track origin/main
+      creates: ~/.git
+    register: cloned_dotfile
+
+  - name: Update the dotfile repo
+    command:
+      cmd: git pull --rebase
+      chdir: ~/
+    when: not cloned_dotfile.changed
+    register: updated_dotfile
+    changed_when: '"Already up to date" not in updated_dotfile.stdout'
+

--- a/roles/emacs/tasks/main.yml
+++ b/roles/emacs/tasks/main.yml
@@ -1,0 +1,39 @@
+---
+- name: Spacemacs Block
+  tags: spacemacs
+  block:
+  - name: Tap the Emacs Plus repository
+    homebrew_tap:
+      name: d12frosted/emacs-plus
+    become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+    become_user: "{{ homebrew_user }}"
+
+  - name: Install Emacs Plus
+    homebrew:
+      name: emacs-plus@30
+      install_options: with-elrumo2-icon
+    become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+    become_user: "{{ homebrew_user }}"
+
+  - name: Start Emacs Plus Service
+    command: brew services start d12frosted/emacs-plus/emacs-plus@30
+    register: start_emacs_service
+    changed_when: '"Successfully started" in start_emacs_service.stdout'
+
+  - name: Symlink the Emacs.app to /Applications
+    file:
+      src: "{{ brew_prefix.stdout }}/opt/emacs-plus@30/Emacs.app"
+      dest: /Applications/Emacs.app
+      state: link
+
+  - name: Check if Spacemacs has been initialized
+    stat:
+      path: ~/.emacs.d/
+    register: spacemacs_stat
+
+  - name: Keep Spacemacs up-to-date
+    git:
+      repo: https://github.com/syl20bnr/spacemacs.git
+      dest: ~/.emacs.d/
+      version: develop
+

--- a/roles/folders/tasks/main.yml
+++ b/roles/folders/tasks/main.yml
@@ -1,0 +1,11 @@
+---
+- name: Set up my folder structure
+  file:
+    path: "{{ item }}"
+    state: directory
+  loop:
+    - ~/Source/Projects
+    - ~/Source/Forks
+    - ~/Source/Work
+  tags: folder-structure
+

--- a/roles/fzf/tasks/main.yml
+++ b/roles/fzf/tasks/main.yml
@@ -1,0 +1,7 @@
+---
+- name: Configure fzf
+  command:
+    cmd: "{{ brew_prefix.stdout }}/opt/fzf/install"
+    creates: ~/.fzf.bash
+  tags: fzf
+

--- a/roles/homebrew_base/tasks/main.yml
+++ b/roles/homebrew_base/tasks/main.yml
@@ -1,0 +1,21 @@
+---
+- name: Set up Homebrew (and upgrade all packages)
+  include_role:
+    name: geerlingguy.mac.homebrew
+  vars:
+    # homebrew_upgrade_all_packages: false # add a var to override
+    # homebrew_installed_packages:
+    # homebrew_uninstalled_packages:
+    # homebrew_cask_apps:
+    # homebrew_cask_uninstalled_apps:
+  tags:
+    - homebrew
+    - homebrew-setup
+
+- name: Get Homebrew's prefix
+  command: brew --prefix
+  register: brew_prefix
+  changed_when: false
+  tags:
+    - homebrew
+

--- a/roles/macos_dock/tasks/main.yml
+++ b/roles/macos_dock/tasks/main.yml
@@ -1,0 +1,66 @@
+---
+- name: Configure Dock & Mission Control
+  tags: dock
+  block:
+
+  - name: On your right
+    osx_defaults:
+      domain: com.apple.dock
+      key: orientation
+      type: string
+      value: right
+      state: present
+    register: dock_is_right
+
+  - name: Duck!
+    osx_defaults:
+      domain: com.apple.dock
+      key: autohide
+      type: bool
+      value: true
+      state: present
+    register: dock_duck
+
+  - name: Don't you dare to bounce (Dock icons, I am talking to you)
+    osx_defaults:
+      domain: com.apple.dock
+      key: no-bouncing
+      type: bool
+      value: true
+      state: present
+    register: dock_no_bounce
+
+  - name: Only show me running apps in the Dock
+    block:
+
+    - name: Only show me running apps in the Dock
+      osx_defaults:
+        domain: com.apple.dock
+        key: static-only
+        type: bool
+        value: true
+        state: present
+      register: dock_only_running_apps
+
+    - name: No suggested and recent apps in the Dock please
+      osx_defaults:
+        domain: com.apple.dock
+        key: show-recents
+        type: bool
+        value: false
+        state: present
+      register: dock_no_suggestion_no_recents
+
+  - name: Don't rearrange my spaces please
+    osx_defaults:
+      domain: com.apple.dock
+      key: mru-spaces
+      type: bool
+      value: false
+      state: present
+    register: mission_control_no_auto_rearrange
+
+  - name: Kill it! Kill it now! (Dock)
+    command: killall Dock
+    when: dock_is_right.changed or dock_duck.changed or dock_no_bounce.changed or dock_only_running_apps.changed or dock_no_suggestion_no_recents.changed or mission_control_no_auto_rearrange.changed
+

--- a/roles/macos_finder/tasks/main.yml
+++ b/roles/macos_finder/tasks/main.yml
@@ -1,0 +1,50 @@
+---
+- name: Configure Finder
+  tags: finder
+  block:
+
+  - name: Show path bar
+    osx_defaults:
+      domain: com.apple.finder
+      key: ShowPathbar
+      type: bool
+      value: true
+      state: present
+    register: finder_path_bar
+
+  - name: Show column view by default
+    osx_defaults:
+      domain: com.apple.finder
+      key: FXPreferredViewStyle
+      type: string
+      value: clmv
+      state: present
+    register: finder_column_view
+
+  - name: Keep folders on top
+    osx_defaults:
+      domain: com.apple.finder
+      key: _FXSortFoldersFirst
+      type: bool
+      value: true
+      state: present
+    register: finder_folders_on_top
+
+  - name: Search current folder by default
+    osx_defaults:
+      domain: com.apple.finder
+      key: FXDefaultSearchScope
+      type: string
+      value: SCcf
+      state: present
+    register: finder_search_current_folder
+
+  - name: Remove outdated (30 days) trash items
+    osx_defaults:
+      domain: com.apple.finder
+      key: FXRemoveOldTrashItems
+      type: bool
+      value: true
+      state: present
+    register: finder_trash_old_trash
+

--- a/roles/macos_stage_manager/tasks/main.yml
+++ b/roles/macos_stage_manager/tasks/main.yml
@@ -1,0 +1,26 @@
+---
+- name: Configure Stage Manager
+  tags: stage-manager
+  block:
+
+  # Found a few settings here: https://forum.latenightsw.com/t/stage-manager-control-from-applescript/4303
+  # `GloballyEnabled`: Enabled or not
+  # `AppWindowGroupingBehavior`: Show windows from an application - All at once vs. One at a time
+  # `HideDesktop`: Show items in Stage Manager
+
+  - name: Enable Stage Manager
+    osx_defaults:
+      domain: com.apple.WindowManager
+      key: GloballyEnabled
+      type: bool
+      value: true
+      state: present
+
+  - name: Show desktop items in Stage Manager
+    osx_defaults:
+      domain: com.apple.WindowManager
+      key: HideDesktop
+      type: bool
+      value: false
+      state: present
+

--- a/roles/preflight/tasks/main.yml
+++ b/roles/preflight/tasks/main.yml
@@ -1,0 +1,10 @@
+---
+- name: Let me check your password first
+  command: echo "Password test in progress..."
+  timeout: 1
+  become: true
+  changed_when: false
+
+- debug:
+    msg: Hello, World!
+

--- a/roles/python_env/tasks/main.yml
+++ b/roles/python_env/tasks/main.yml
@@ -1,0 +1,28 @@
+---
+- name: Ensure Ansible is installed with Homebrew's pip
+  pip:
+    name: ansible
+  vars:
+    extra_path: "{{ brew_prefix.stdout }}/bin"
+  tags:
+    - python
+    - ansible
+
+- name: Install poetry
+  homebrew:
+    name: poetry
+  become: true
+  become_user: "{{ homebrew_user }}"
+  tags:
+    - python
+    - poetry
+
+- name: Set Up The Root Virtual Environment
+  command:
+    cmd: poetry install --no-root
+    chdir: ~/
+    creates: ~/poetry.lock
+  tags:
+    - python
+    - poetry
+

--- a/roles/shell_fish/tasks/main.yml
+++ b/roles/shell_fish/tasks/main.yml
@@ -1,0 +1,22 @@
+---
+- name: Set up fishshell as the default shell
+  tags: fishshell
+  block:
+
+  - name: Get fishshell's path
+    command: which fish
+    register: fish
+    changed_when: false
+
+  - name: Ensure fishshell is included in /etc/shells
+    lineinfile:
+      path: /etc/shells
+      line: "{{ fish.stdout }}"
+    become: true
+
+  - name: Ensure current user's default shell is fish
+    user:
+      name: "{{ ansible_user_id }}"
+      shell: "{{ fish.stdout }}"
+    become: true
+

--- a/roles/ssh/tasks/main.yml
+++ b/roles/ssh/tasks/main.yml
@@ -1,0 +1,25 @@
+---
+- name: Set up SSH key pair
+  tags: ssh
+  block:
+
+  - name: Check if SSH key pair exists
+    stat:
+      path: "{{ ssh_private_key_path }}"
+    register: ssh_private_key
+
+  - name: Set up SSH key pair
+    block:
+
+      - name: Get the passphrase for the SSH key pair
+        pause:
+          prompt: "Enter the passphrase"
+          echo: no
+        register: passphrase
+
+      - name: Generate the SSH key pair
+        command: "{{ ssh_keygen_command }}"
+
+    when: not ssh_private_key.stat.exists
+    no_log: true
+

--- a/roles/vim/tasks/main.yml
+++ b/roles/vim/tasks/main.yml
@@ -1,0 +1,49 @@
+---
+- name: Vim Block # Caveats: Vim's plugins aren't installed after this...
+  tags: vim
+  block:
+  - name: Install Vim
+    homebrew:
+      name: "{{ item }}"
+    loop:
+      - vim
+      - cmake
+    become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+    become_user: "{{ homebrew_user }}"
+
+  - name: Check if Vim plugins are installed
+    stat:
+      path: ~/.vim-plugins/
+    register: vim_plugins_stat
+
+  - name: Bootstrap Vim plugins if plugins are not installed yet
+    command: vim
+    async: 90
+    poll: 0
+    when: not vim_plugins_stat.stat.exists
+
+  - name: Check if YouCompleteMe is there
+    stat:
+      path: ~/.vim-plugins/plugins/YouCompleteMe/
+    register: YCM_stat
+
+  - name: Check if YouCompleteMe has been compiled
+    stat:
+      path: ~/.vim-plugins/plugins/YouCompleteMe/.compiled
+    register: YCM_compiled
+
+  - name: Compile YouCompleteMe
+    block:
+
+    - name: Compile YouCompleteMe
+      command:
+        cmd: python3 install.py
+        chdir: ~/.vim-plugins/plugins/YouCompleteMe
+
+    - name: Mark YCM as compiled
+      file:
+        path: ~/.vim-plugins/plugins/YouCompleteMe/.compiled
+        state: touch
+
+    when: YCM_stat.stat.exists and not YCM_compiled.stat.exists
+


### PR DESCRIPTION
Purpose
- Split monolithic main.yml into reusable roles and separate macOS defaults into dedicated roles for better composability and targeted runs.

Summary
- Add roles: preflight, dotfiles, ssh, homebrew_base, dev_tools, casks, emacs, vim, python_env, shell_fish, fzf, folders.
- Add macOS defaults roles: macos_finder, macos_stage_manager, macos_dock.
- Rewire main.yml to a slim roles list; preserve variables and tags.
- Update README with new structure, tags, examples, and dependency notes.

Scope
- Files/roles touched: main.yml, README.md, roles/* (added 15 roles with tasks/main.yml), existing roles/shared_fonts unchanged.
- Tags preserved: homebrew, homebrew-setup, spacemacs, vim, python, poetry, fishshell, fzf, folder-structure, finder, stage-manager, dock, dotfiles, ssh.

Verification
- Syntax check: `ansible-playbook -i inventory --syntax-check main.yml`
- Tags listing: `ansible-playbook -i inventory --list-tags main.yml`
- Targeted examples:
  - `ansible-playbook -i inventory -K main.yml --tags homebrew`
  - `ansible-playbook -i inventory -K main.yml --tags finder,stage-manager,dock`
  - `ansible-playbook -i inventory -K main.yml --tags spacemacs,vim`
  - `ansible-playbook -i inventory -K main.yml --tags ssh -e generate_ssh=true`

Idempotence
- Tasks remain idempotent as before (uses osx_defaults, homebrew modules, and guarded command tasks with `creates`/conditionals). No behavioral changes intended.

Notes
- `homebrew_base` registers `brew_prefix`; roles `emacs`, `python_env`, and `fzf` assume it ran. When targeting, include `--tags homebrew` if running these in isolation on a fresh machine.