### PR TITLE
Add role to install openai codex npm package

### DIFF
--- a/main.yml
+++ b/main.yml
@@ -38,6 +38,9 @@
     - role: dev_tools
       tags: [homebrew]
 
+    - role: openai_codex
+      tags: [npm, codex]
+
     - role: shell_fish
       tags: [fishshell]
 

--- a/roles/openai_codex/tasks/main.yml
+++ b/roles/openai_codex/tasks/main.yml
@@ -1,0 +1,12 @@
+---
+- name: Install openai/codex npm package
+  npm:
+    name: openai/codex
+    global: true
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  tags:
+    - npm
+    - codex
+


### PR DESCRIPTION
## Summary
- add `openai_codex` role for installing the `openai/codex` npm package
- include `openai_codex` in the main playbook

## Testing
- `ansible-playbook -i inventory --syntax-check main.yml` *(fails: command not found)*
- `apt-get update` *(fails: repository 403)*
- `python3 -m pip install ansible` *(fails: proxy 403)*

------
https://chatgpt.com/codex/tasks/task_e_6896bb844a048323803387524aeaf8c2