### PR TITLE
Add flags for optional cask groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,20 @@ Notes on dependencies when targeting:
 
 - Some roles rely on `homebrew_base` to have run (because it registers `brew_prefix` and ensures Homebrew): `emacs`, `python_env`, and `fzf` in particular. When running these tags alone, include `homebrew` too, e.g.: `--tags homebrew,spacemacs` or `--tags homebrew,python`.
 - `casks` and `dev_tools` also assume Homebrew is installed; include `--tags homebrew` if you are targeting them on a fresh machine.
+ 
+## Optional cask groups
+
+The `casks` role installs a base set of applications. Gaming and streaming/recording tools are enabled by default.
+Skip them by setting the following variables to `false` when invoking the playbook:
+
+- `install_gaming_casks` installs `steam`
+- `install_streaming_casks` installs `obs`, `audio-hijack`, and `loopback`
+
+Example:
+
+```bash
+ansible-playbook -i inventory -K main.yml -e install_gaming_casks=false -e install_streaming_casks=false
+```
 
 ## Credits
 

--- a/main.yml
+++ b/main.yml
@@ -14,6 +14,9 @@
     ssh_private_key_path: "~/.ssh/id_{{ ssh_type }}"
     ssh_keygen_command: "ssh-keygen -o -t {{ ssh_type }} -a {{ ssh_rounds }} -N '{{ passphrase.user_input }}' -f {{ ssh_private_key_path }}"
 
+    install_gaming_casks: true
+    install_streaming_casks: true
+
   roles:
     - role: preflight
 

--- a/roles/casks/tasks/main.yml
+++ b/roles/casks/tasks/main.yml
@@ -36,15 +36,6 @@
     # 3d modeling & printing
     # - autodesk-fusion
     # - bambu-studio
-
-    # gaming
-    - steam
-
-    # streaming / recording
-    - obs
-    - audio-hijack
-    - loopback
-
     - vlc
     # - elgato-stream-deck
 
@@ -52,5 +43,31 @@
     # - protonvpn
     # - parsec
 
+  tags:
+    - homebrew
+
+- name: Install gaming casks
+  homebrew_cask:
+    name: "{{ item }}"
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  loop:
+    - steam
+  when: install_gaming_casks
+  tags:
+    - homebrew
+
+- name: Install streaming/recording casks
+  homebrew_cask:
+    name: "{{ item }}"
+    state: present
+  become: "{{ (homebrew_user != ansible_user_id) | bool }}"
+  become_user: "{{ homebrew_user }}"
+  loop:
+    - obs
+    - audio-hijack
+    - loopback
+  when: install_streaming_casks
   tags:
     - homebrew


### PR DESCRIPTION
## Summary
- add `install_gaming_casks` and `install_streaming_casks` playbook flags (enabled by default)
- split gaming and streaming casks into separate conditional tasks
- document optional cask groups and how to disable them

## Testing
- `pip install ansible` *(fails: Tunnel connection failed: 403 Forbidden)*
- `ansible-playbook -i inventory --syntax-check main.yml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68993eb0c26c832390f047ab28fe19e9